### PR TITLE
Add Travis-CI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ typings/
 /public/stylesheets
 
 ## grunt-ts
-.baseDir.ts
+.baseDir*
 
 # SASS
 public/stylesheets/*.css

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: node_js
+# We use Ruby because we need rvm, but unforunately, on OSX we have to manually install nvm via homebrew.
+# See: https://github.com/travis-ci/travis-ci/issues/2311
+
+os:
+  - linux
+#  - osx
+
+node_js:
+  - 5.3
+  - 4.2
+
+cache:
+  directories:
+    # tsd
+    - $TRAVIS_BUILD_DIR/typings/
+
+    # npm
+    - $TRAVIS_BUILD_DIR/node_modules/
+
+before_install:
+#  - git clone https://github.com/creationix/nvm.git /tmp/.nvm
+#  - source /tmp/.nvm/nvm.sh
+#  - nvm install $NODE_VERSION
+#  - nvm use $NODE_VERSION
+
+#  Versions:
+  - node --version
+  - npm --version
+
+install:
+  - npm install -g tsd grunt-cli
+  - npm install
+  - tsd install
+  - gem install sass
+
+before_script:
+  - grunt build
+
+script:
+  - npm test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
         ts: {
             app: {
                 outDir: '.',
-                src: ['app.ts'],
+                src: ['src/app.ts'],
 
                 options: {
                     module: 'commonjs', //or commonjs
@@ -109,8 +109,7 @@ module.exports = function(grunt) {
 
         clean: {
             js: ['public/js/**/*.js', 'public/js/**/*.map', 'public/js/**/*.d.ts',
-                 'routes/**/*.js', 'routes/**/*.map', 'routes/**/*.d.ts',
-                 'app.js*', 'app.d.ts'],
+                 'routes/**/*.js', 'routes/**/*.map', 'routes/**/*.d.ts'],
             css: ['public/stylesheets/**/*.css', 'public/stylesheets/**/*.map']
         }
 
@@ -124,6 +123,10 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-ts');
 
-    grunt.registerTask('default', ['jshint', 'clean', 'ts', 'concat', 'sass', 'uglify']);
+    grunt.registerTask('init', ['jshint', 'clean']);
 
+    grunt.registerTask('build', ['init', 'ts:routes', 'ts:app', 'ts:client', 'sass']);
+    grunt.registerTask('dist', ['build', 'concat', 'uglify']);
+
+    grunt.registerTask('default', 'build');
 };

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Procsim-js
+# UmpleOnline
+[![Build Status](https://travis-ci.org/Nava2/umpleonline.svg?branch=master)](https://travis-ci.org/Nava2/umpleonline)
+
+## Prerequisites
+
+* [node.js 5.x+](https://nodejs.org/en/download/stable/)
+* [Ruby](https://www.ruby-lang.org/en/downloads/)
 
 ## Build Instructions
 
 1. Install [nodejs 5.x+](https://nodejs.org/en/download/stable/)
 2. Install Sass: `gem install sass`
-3. Install TypeScript, tsd, and grunt-cli: `npm install typescript tsd grunt-cli -g`
-4. Clone source code: `git clone TODO`
+3. Install TypeScript, tsd, and grunt-cli: `npm install tsd grunt-cli -g`
+4. Clone source code: `git clone git@github.com:Nava2/umpleonline.git`
 5. Install npm components: `npm install`
 6. Run tsd: `tsd install`
 7. Run `grunt`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "test": "grunt "
   },
   "dependencies": {
     "body-parser": "~1.13.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-/// <reference path='typings/tsd.d.ts' />
+/// <reference path='../typings/tsd.d.ts' />
 
 import express = require('express');
 import path = require('path');
@@ -24,8 +24,8 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/', routes);
-app.use('/users', users);
+app.use(/\//, routes);
+app.use(/\/users/, users);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -2,7 +2,7 @@
  * Created by kevin on 05/01/16.
  */
 
-/// <reference path='../../typings/jquery/jquery.d.ts' />
+/// <reference path='../../typings/tsd.d.ts' />
 
 $(() => {
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,7 @@
-/// <reference path='../../typings/express/express.d.ts' />
+/// <reference path='../../typings/tsd.d.ts' />
 
 import express = require('express');
-var router = express.Router();
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
@@ -60,4 +60,4 @@ router.get('/', function(req, res, next) {
   });
 });
 
-module.exports = router;
+export = router;

--- a/tsd.json
+++ b/tsd.json
@@ -43,6 +43,9 @@
     },
     "assert/assert.d.ts": {
       "commit": "efd40e67ff323f7147651bdbef03c03ead7b1675"
+    },
+    "jquery/jquery.d.ts": {
+      "commit": "6a6ad7068a177c0d7a8a20830626cb63277191c5"
     }
   }
 }

--- a/views/navbar.jade
+++ b/views/navbar.jade
@@ -53,32 +53,21 @@ nav.navbar.navbar-default.navbar-fixed-top
           //- Umpr
           a.navbar-link(href="http://umpr.umple.org/")
             i.fa.fa-external-link-square
-            | &nbsp; Umpr
+            | &nbsp;Umpr
 
-      form.navbar-form.navbar-left(role='search')
+      //form.navbar-form.navbar-left(role='search')
+      //  .form-group
+      //    input.form-control(type='text')
+      //
+      //  button.btn.btn-default(type='submit') Submit
+
+      form#generateForm.navbar-form.navbar-right
         .form-group
-          input.form-control(type='text')
 
-        button.btn.btn-default(type='submit') Submit
+          //- Class Diagrams
+          label.sr-only(for='generateLanguageSelect') Select a Language to Generate
+          select#generateLanguageSelect.selectpicker(title='Choose Language...')
+            each desc, file in locals.classDiagrams
+              option(value='#{file}.ump', data-subtext='#{file}.ump')= desc
 
-      ul.nav.navbar-nav.navbar-right
-        li
-          a(href='#') Link
-        li.dropdown
-          a.dropdown-toggle(href='#', data-toggle='dropdown') Dropdown
-            strong.caret
-
-          ul.dropdown-menu
-            li
-              a(href='#') Action
-
-            li
-              a(href='#') Another action
-
-            li
-              a(href='#') Something else here
-
-            li.divider
-
-            li
-              a(href='#') Separated link
+          button.btn.btn-default Generate


### PR DESCRIPTION
This adds support for building with Travis-CI. This works two-fold: 
1) I now know that I can confirm building the application outside of WebStorm.
2) Tests can be run (when I get some :+1:)
- Moved app.ts into src/ to better find routes/
- Adjusted `tsd` dependencies to be accurate (missed a few!)
- Fixed compiler warnings from `tsc`
